### PR TITLE
Add shared SPI bus support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -186,6 +186,12 @@ config MIPI_DISPLAY_SPI_HOST
     default 0x02 if ESP32S3_SPI3_SELECTED
 endif
 
+config MIPI_DISPLAY_EXCLUSIVE_BUS
+    bool "Exclusive SPI Bus"
+    default y
+    help
+        Display uses SPI Host exclusively. No other devices share the same SPI bus.
+
 config MIPI_DISPLAY_PIN_MISO
     int "MISO pin number"
     default -1

--- a/include/mipi_display.h
+++ b/include/mipi_display.h
@@ -66,6 +66,7 @@ extern "C" {
 void mipi_display_init(spi_device_handle_t *spi);
 size_t mipi_display_write(spi_device_handle_t spi, uint16_t x1, uint16_t y1, uint16_t w, uint16_t h, uint8_t *buffer);
 void mipi_display_ioctl(spi_device_handle_t spi, uint8_t command, uint8_t *data, size_t size);
+void mipi_display_open(spi_device_handle_t spi);
 void mipi_display_close(spi_device_handle_t spi);
 
 #ifdef __cplusplus

--- a/src/hagl_hal_double.c
+++ b/src/hagl_hal_double.c
@@ -67,16 +67,21 @@ static const char *TAG = "hagl_esp_mipi";
 static size_t
 flush(void *self)
 {
-#ifdef CONFIG_HAGL_HAL_LOCK_WHEN_FLUSHING
     size_t size = 0;
+#ifdef CONFIG_HAGL_HAL_LOCK_WHEN_FLUSHING
     /* Flush the whole back buffer with locking. */
     xSemaphoreTake(mutex, portMAX_DELAY);
+    mipi_display_open(spi);
     size = mipi_display_write(spi, 0, 0, bb.width, bb.height, (uint8_t *) bb.buffer);
+    mipi_display_close(spi);
     xSemaphoreGive(mutex);
     return size;
 #else
     /* Flush the whole back buffer. */
-    return mipi_display_write(spi, 0, 0, bb.width, bb.height, (uint8_t *) bb.buffer);
+    mipi_display_open(spi);
+    size = mipi_display_write(spi, 0, 0, bb.width, bb.height, (uint8_t *) bb.buffer);
+    mipi_display_close(spi);
+    return size;
 #endif /* CONFIG_HAGL_HAL_LOCK_WHEN_FLUSHING */
 }
 

--- a/src/hagl_hal_single.c
+++ b/src/hagl_hal_single.c
@@ -98,6 +98,18 @@ vline(void *self, int16_t x0, int16_t y0, uint16_t height, hagl_color_t color)
     mipi_display_write(spi, x0, y0, width, height, (uint8_t *) line);
 }
 
+static void
+begin(void *self)
+{
+    mipi_display_open(spi);
+}
+
+static void
+end(void *self)
+{
+    mipi_display_close(spi);
+}
+
 void
 hagl_hal_init(hagl_backend_t *backend)
 {
@@ -111,5 +123,7 @@ hagl_hal_init(hagl_backend_t *backend)
     backend->hline = hline;
     backend->vline = vline;
     backend->blit = blit;
+    backend->begin = begin;
+    backend->end = end;
 }
 #endif /* CONFIG_HAGL_HAL_NO_BUFFERING */

--- a/src/hagl_hal_triple.c
+++ b/src/hagl_hal_triple.c
@@ -73,7 +73,10 @@ flush(void *self)
     } else {
         bb.buffer = buffer1;
     }
-    return mipi_display_write(spi, 0, 0, bb.width, bb.height, (uint8_t *) buffer);
+    mipi_display_open(spi);
+    size_t size = mipi_display_write(spi, 0, 0, bb.width, bb.height, (uint8_t *) buffer);
+    mipi_display_close(spi);
+    return size;
 }
 
 static void

--- a/src/mipi_display.c
+++ b/src/mipi_display.c
@@ -280,7 +280,9 @@ void mipi_display_init(spi_device_handle_t *spi)
 
     ESP_LOGI(TAG, "Display initialized.");
 
+#ifdef CONFIG_MIPI_DISPLAY_EXCLUSIVE_BUS
     spi_device_acquire_bus(*spi, portMAX_DELAY);
+#endif
 }
 
 void mipi_display_ioctl(spi_device_handle_t spi, const uint8_t command, uint8_t *data, size_t size)
@@ -317,7 +319,16 @@ void mipi_display_ioctl(spi_device_handle_t spi, const uint8_t command, uint8_t 
     xSemaphoreGive(mutex);
 }
 
+void mipi_display_open(spi_device_handle_t spi)
+{
+#ifndef CONFIG_MIPI_DISPLAY_EXCLUSIVE_BUS
+    spi_device_acquire_bus(spi, portMAX_DELAY);
+#endif
+}
+
 void mipi_display_close(spi_device_handle_t spi)
 {
+#ifndef CONFIG_MIPI_DISPLAY_EXCLUSIVE_BUS
     spi_device_release_bus(spi);
+#endif
 }


### PR DESCRIPTION
Add hint functions that allow the SPI bus to be acquired efficiently when the bus needs to be shared with other devices.

See: https://github.com/saawsm/hagl/pull/1